### PR TITLE
feat(ui): display crews list from API

### DIFF
--- a/game-site/src/App.tsx
+++ b/game-site/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import CrewList from './components/CrewList'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -28,6 +29,7 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <CrewList />
     </>
   )
 }

--- a/game-site/src/components/CrewList.tsx
+++ b/game-site/src/components/CrewList.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+
+interface CrewMember {
+  name: string
+  role: string
+}
+
+interface Crew {
+  id: number | string
+  name: string
+  members: CrewMember[]
+}
+
+function CrewList() {
+  const [crews, setCrews] = useState<Crew[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    async function loadCrews() {
+      try {
+        const res = await fetch('/api/crews')
+        if (!res.ok) {
+          throw new Error('Failed to load crews')
+        }
+        const data = await res.json()
+        setCrews(data)
+      } catch {
+        setError('Unable to load crews. Please try again later.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadCrews()
+  }, [])
+
+  if (error) {
+    return <p role="alert">{error}</p>
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <section aria-labelledby="crews-heading">
+      <h1 id="crews-heading">Crews</h1>
+      {crews.map((crew) => (
+        <article key={crew.id}>
+          <h2>{crew.name}</h2>
+          <ul>
+            {crew.members.map((member) => (
+              <li key={member.name}>
+                {member.name} - {member.role}
+              </li>
+            ))}
+          </ul>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+export default CrewList


### PR DESCRIPTION
## Summary
- add `CrewList` component to display crews and members
- show loading and errors during fetch
- mount `CrewList` in `App`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e11592cc4832ab6058a4cf8160ff1