### PR TITLE
Add Vite dev server proxy

### DIFF
--- a/game-site/vite.config.ts
+++ b/game-site/vite.config.ts
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    // Proxy API requests during local development
+    // '/api' -> 'http://localhost:3000'
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- enable proxying of `/api` to the backend server in Vite config

## Testing
- `npm run lint` within `game-site`
- `npm run build` within `game-site`


------
https://chatgpt.com/codex/tasks/task_e_684e11619164832a92dc35cf555ded9a