### PR TITLE
docs: document crew API and frontend integration

### DIFF
--- a/docs/mechanics.md
+++ b/docs/mechanics.md
@@ -1,1 +1,39 @@
-﻿# Game Mechanics
+# Game Mechanics
+
+## Crew API & Display Example
+
+The backend provides a simple sample endpoint for retrieving bomber crew data.
+
+### Endpoint
+
+`GET /api/crews`
+
+Returns a JSON array of crews with their members. Example response:
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Lancaster Alpha",
+    "members": [
+      {"name": "John Smith", "role": "Pilot"},
+      {"name": "Mike Brown", "role": "Navigator"}
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Lancaster Bravo",
+    "members": [
+      {"name": "Alice Johnson", "role": "Pilot"},
+      {"name": "Robert Lee", "role": "Bombardier"}
+    ]
+  }
+]
+```
+
+### Frontend Integration
+
+The `CrewList` React component (located in `/game-site/src/components/CrewList.tsx`) fetches this endpoint on mount. The Vite dev server proxies `/api` requests to the backend, so the data loads automatically during development. Once fetched, each crew name and member role is displayed in an accessible list.
+
+![Crew list screenshot](img/crew-list-placeholder.png)
+


### PR DESCRIPTION
## Summary
- document the `/api/crews` endpoint
- explain how the frontend fetches and displays crews
- add placeholder screenshot image

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` in `game-site`
- `npm run build` in `game-site`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_684e1167cd10832ab1f678bd195b2a36