### PR TITLE
feat(api): import procedural crew seed data

### DIFF
--- a/backend/data/familyHobbies.json
+++ b/backend/data/familyHobbies.json
@@ -1,0 +1,1 @@
+["Married with two kids","Single","Enjoys football","Gardening","Reading"]

--- a/backend/data/firstNames.json
+++ b/backend/data/firstNames.json
@@ -1,0 +1,1 @@
+["John","Alice","Robert","Sarah","Michael"]

--- a/backend/data/hometowns.json
+++ b/backend/data/hometowns.json
@@ -1,0 +1,1 @@
+["London","Manchester","Birmingham","Liverpool","Leeds"]

--- a/backend/data/lastNames.json
+++ b/backend/data/lastNames.json
@@ -1,0 +1,1 @@
+["Smith","Johnson","Brown","Williams","Jones"]

--- a/backend/data/occupations.json
+++ b/backend/data/occupations.json
@@ -1,0 +1,1 @@
+["Farmer","Teacher","Engineer","Clerk","Mechanic"]

--- a/backend/data/religions.json
+++ b/backend/data/religions.json
@@ -1,0 +1,1 @@
+["Anglican","Catholic","Methodist","Jewish","None"]

--- a/backend/data/socioeconomicBackgrounds.json
+++ b/backend/data/socioeconomicBackgrounds.json
@@ -1,0 +1,1 @@
+["Working Class","Middle Class","Upper Class"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "seed": "node scripts/seedData.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,3 +13,38 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model FirstName {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model LastName {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model Hometown {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model Occupation {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model Religion {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model SocioeconomicBackground {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}
+
+model FamilyHobby {
+  id    Int    @id @default(autoincrement())
+  value String @unique
+}

--- a/backend/scripts/seedData.js
+++ b/backend/scripts/seedData.js
@@ -1,0 +1,74 @@
+const fs = require('fs/promises');
+const path = require('path');
+const { PrismaClient } = require('../src/generated/prisma');
+
+const prisma = new PrismaClient();
+
+/**
+ * Read a JSON or CSV file and return an array of string values.
+ * @param {string} filePath - Path to the data file.
+ * @returns {Promise<string[]>}
+ */
+async function readDataFile(filePath) {
+  const data = await fs.readFile(filePath, 'utf8');
+  if (filePath.endsWith('.json')) {
+    return JSON.parse(data);
+  }
+  // Simple CSV parsing: split by comma or newlines
+  return data.split(/,|\n/).map(v => v.trim()).filter(Boolean);
+}
+
+/**
+ * Load lookup data from files and insert into the database.
+ */
+async function main() {
+  const dataDir = path.join(__dirname, '../data');
+
+  const firstNames = await readDataFile(path.join(dataDir, 'firstNames.json'));
+  const lastNames = await readDataFile(path.join(dataDir, 'lastNames.json'));
+  const hometowns = await readDataFile(path.join(dataDir, 'hometowns.json'));
+  const occupations = await readDataFile(path.join(dataDir, 'occupations.json'));
+  const religions = await readDataFile(path.join(dataDir, 'religions.json'));
+  const socioeconomic = await readDataFile(
+    path.join(dataDir, 'socioeconomicBackgrounds.json')
+  );
+  const familyHobbies = await readDataFile(path.join(dataDir, 'familyHobbies.json'));
+
+  await prisma.firstName.createMany({
+    data: firstNames.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.lastName.createMany({
+    data: lastNames.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.hometown.createMany({
+    data: hometowns.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.occupation.createMany({
+    data: occupations.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.religion.createMany({
+    data: religions.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.socioeconomicBackground.createMany({
+    data: socioeconomic.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+  await prisma.familyHobby.createMany({
+    data: familyHobbies.map(value => ({ value })),
+    skipDuplicates: true,
+  });
+}
+
+main()
+  .catch(err => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- add Prisma models for lookup tables
- seed data script to load procedural name and background lists
- add sample JSON seed data
- connect `npm run seed` to execute the script

## Testing
- `npx prisma generate`
- `npm run seed` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ee45044832ab022726808cb3bf9