### PR TITLE
feat(api): add parcel open/lookup endpoints

### DIFF
--- a/backend/src/routes/crews.js
+++ b/backend/src/routes/crews.js
@@ -27,6 +27,22 @@ const crews = [
 ];
 
 const router = express.Router();
+const { user } = require('./user');
+
+// In-memory parcel slots keyed by crew id
+const crewParcels = {};
+
+// Simple placeholder card templates
+const cardTemplates = [
+  { id: 'talisman-1' },
+  { id: 'object-1' },
+  { id: 'event-1' },
+];
+
+const randomCardId = () => {
+  const tpl = cardTemplates[Math.floor(Math.random() * cardTemplates.length)];
+  return `${tpl.id}-${Math.random().toString(36).slice(2, 8)}`;
+};
 
 /**
  * GET /api/crews
@@ -107,6 +123,76 @@ router.post('/crews/recruit', async (req, res, next) => {
   } catch (err) {
     next(err);
   }
+});
+
+/**
+ * GET /api/crews/:id/parcels
+ * Returns up to three parcel slots for the crew with opened state.
+ */
+router.get('/crews/:id/parcels', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    return res.status(400).json({ error: 'invalid crew id' });
+  }
+
+  if (!crewParcels[id]) {
+    crewParcels[id] = [
+      { opened: false, cards: [] },
+      { opened: false, cards: [] },
+      { opened: false, cards: [] },
+    ];
+  }
+
+  res.json(crewParcels[id].map(p => ({ opened: p.opened })));
+});
+
+/**
+ * POST /api/crews/:id/parcels/open
+ * Opens the specified parcel slot using stamps and returns cards.
+ * @param {number} req.body.slotIndex Index of the slot to open (0-2)
+ * @param {number} req.body.stamps   Number of stamps to spend
+ */
+router.post('/crews/:id/parcels/open', (req, res) => {
+  const id = Number(req.params.id);
+  const { slotIndex, stamps } = req.body || {};
+
+  if (!Number.isInteger(id)) {
+    return res.status(400).json({ error: 'invalid crew id' });
+  }
+  if (!Number.isInteger(slotIndex) || slotIndex < 0 || slotIndex > 2) {
+    return res.status(400).json({ error: 'slotIndex must be 0-2' });
+  }
+  if (!Number.isInteger(stamps) || stamps <= 0) {
+    return res.status(400).json({ error: 'stamps must be a positive integer' });
+  }
+  if (user.stamps < stamps) {
+    return res.status(400).json({ error: 'not enough stamps' });
+  }
+
+  if (!crewParcels[id]) {
+    crewParcels[id] = [
+      { opened: false, cards: [] },
+      { opened: false, cards: [] },
+      { opened: false, cards: [] },
+    ];
+  }
+
+  const slot = crewParcels[id][slotIndex];
+  if (slot.opened) {
+    return res.status(400).json({ error: 'slot already opened' });
+  }
+
+  user.stamps -= stamps;
+  const cardCount = Math.floor(Math.random() * 3) + 1;
+  const cards = [];
+  for (let i = 0; i < cardCount; i++) {
+    cards.push(randomCardId());
+  }
+
+  slot.opened = true;
+  slot.cards = cards;
+
+  res.json({ parcels: crewParcels[id].map(p => ({ opened: p.opened })), cards });
 });
 
 module.exports = router;

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -49,3 +49,4 @@ router.post('/user/bonds/grant', (req, res) => {
 });
 
 module.exports = router;
+module.exports.user = user;

--- a/docs/mechanics.md
+++ b/docs/mechanics.md
@@ -82,3 +82,40 @@ Adds bonds to the current balance and returns the new total.
 { "bonds": 10 }
 ```
 
+## Crew Parcel API
+
+### Get Crew Parcels
+
+`GET /api/crews/{id}/parcels`
+
+Returns an array of up to three parcel slots for the crew. Each slot shows
+whether it has been opened.
+
+```json
+[
+  { "opened": false },
+  { "opened": true },
+  { "opened": false }
+]
+```
+
+### Open a Parcel
+
+`POST /api/crews/{id}/parcels/open`
+
+Send JSON `{ "slotIndex": 0, "stamps": 1 }` to open the specified slot. The
+user's stamps are deducted and 1–3 random card IDs are generated.
+
+Example response:
+
+```json
+{
+  "parcels": [
+    { "opened": true },
+    { "opened": false },
+    { "opened": false }
+  ],
+  "cards": ["talisman-1-ab12cd"]
+}
+```
+


### PR DESCRIPTION
## Summary
- implement crew parcel endpoints
- expose user data for parcel logic
- document parcel API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_684e23640c88832a8b33959476afd6e2