### PR TITLE
feat(api): add Card model and template endpoints

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -74,3 +74,12 @@ model CrewMember {
   socioeconomicBackground SocioeconomicBackground @relation(fields: [socioeconomicBackgroundId], references: [id])
   familyHobby      FamilyHobby            @relation(fields: [familyHobbyId], references: [id])
 }
+
+model Card {
+  id          String @id @default(uuid())
+  type        String
+  rarity      String
+  name        String
+  description String
+  effects     Json
+}

--- a/backend/src/routes/cards.js
+++ b/backend/src/routes/cards.js
@@ -1,0 +1,45 @@
+const express = require('express');
+
+/**
+ * Basic card template definitions. These would normally come from the database.
+ * @type {Array<{id:string,type:string,rarity:string,name:string,description:string,effects:object}>}
+ */
+const cardTemplates = [
+  {
+    id: 'character-ace',
+    type: 'character',
+    rarity: 'rare',
+    name: 'Ace Pilot',
+    description: 'Improves mission success chance',
+    effects: { skill: '+1' },
+  },
+  {
+    id: 'object-map',
+    type: 'object',
+    rarity: 'common',
+    name: 'Navigational Map',
+    description: 'Helps keep the squadron on course',
+    effects: { navigate: '+1' },
+  },
+  {
+    id: 'talisman-charm',
+    type: 'talisman',
+    rarity: 'exclusive',
+    name: 'Lucky Charm',
+    description: 'Boosts crew morale',
+    effects: { morale: '+2' },
+  },
+];
+
+const router = express.Router();
+
+/**
+ * GET /api/cards/templates
+ * Returns all available card templates.
+ */
+router.get('/cards/templates', (req, res) => {
+  res.json(cardTemplates);
+});
+
+module.exports = router;
+module.exports.cardTemplates = cardTemplates;

--- a/backend/src/routes/crews.js
+++ b/backend/src/routes/crews.js
@@ -28,16 +28,13 @@ const crews = [
 
 const router = express.Router();
 const { user } = require('./user');
+const { cardTemplates } = require('./cards');
 
 // In-memory parcel slots keyed by crew id
 const crewParcels = {};
+// In-memory cards assigned to each crew id
+const crewCards = {};
 
-// Simple placeholder card templates
-const cardTemplates = [
-  { id: 'talisman-1' },
-  { id: 'object-1' },
-  { id: 'event-1' },
-];
 
 const randomCardId = () => {
   const tpl = cardTemplates[Math.floor(Math.random() * cardTemplates.length)];
@@ -193,6 +190,30 @@ router.post('/crews/:id/parcels/open', (req, res) => {
   slot.cards = cards;
 
   res.json({ parcels: crewParcels[id].map(p => ({ opened: p.opened })), cards });
+});
+
+/**
+ * POST /api/crews/:id/cards/assign
+ * Assign specific card IDs to the crew.
+ * @param {string[]} req.body.cardIds Array of card IDs to assign
+ */
+router.post('/crews/:id/cards/assign', (req, res) => {
+  const id = Number(req.params.id);
+  const { cardIds } = req.body || {};
+
+  if (!Number.isInteger(id)) {
+    return res.status(400).json({ error: 'invalid crew id' });
+  }
+  if (!Array.isArray(cardIds) || cardIds.some(c => typeof c !== 'string')) {
+    return res.status(400).json({ error: 'cardIds must be an array of strings' });
+  }
+
+  if (!crewCards[id]) {
+    crewCards[id] = [];
+  }
+
+  crewCards[id].push(...cardIds);
+  res.json({ cards: crewCards[id] });
 });
 
 module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const crewsRouter = require('./routes/crews');
 const userRouter = require('./routes/user');
+const cardsRouter = require('./routes/cards');
 
 const app = express();
 app.use(cors());
@@ -10,6 +11,7 @@ app.use(express.json());
 // Mount crew routes under /api
 app.use('/api', crewsRouter);
 app.use('/api', userRouter);
+app.use('/api', cardsRouter);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/docs/mechanics.md
+++ b/docs/mechanics.md
@@ -119,3 +119,35 @@ Example response:
 }
 ```
 
+
+## Card Templates API
+
+### Get Card Templates
+
+`GET /api/cards/templates`
+
+Returns the list of available card templates.
+
+```json
+[
+  {
+    "id": "character-ace",
+    "type": "character",
+    "rarity": "rare",
+    "name": "Ace Pilot",
+    "description": "Improves mission success chance",
+    "effects": { "skill": "+1" }
+  }
+]
+```
+
+### Assign Cards to a Crew
+
+`POST /api/crews/{id}/cards/assign`
+
+Send JSON `{ "cardIds": ["character-ace"] }` to manually assign cards to a crew.
+The endpoint returns the crew's full card list.
+
+```json
+{ "cards": ["character-ace"] }
+```


### PR DESCRIPTION
## Summary
- define new `Card` model in Prisma schema
- expose card template endpoint and manual card assignment
- hook new cards router in the server
- document new API routes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx prisma migrate dev --name add-card` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_684e24e6c708832a9433a414ae2a0e7b