### PR TITLE
feat(ui): scaffoldProfile, Recruit, Parcels, Train, Deploy pages

### DIFF
--- a/game-site/package-lock.json
+++ b/game-site/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1806,6 +1807,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2701,6 +2711,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2801,6 +2849,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/game-site/package.json
+++ b/game-site/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/game-site/src/App.tsx
+++ b/game-site/src/App.tsx
@@ -1,35 +1,32 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { Link, Route, Routes } from 'react-router-dom'
 import CrewList from './components/CrewList'
+import ProfilePage from './pages/ProfilePage'
+import RecruitPage from './pages/RecruitPage'
+import ParcelsPage from './pages/ParcelsPage'
+import TrainPage from './pages/TrainPage'
+import DeployPage from './pages/DeployPage'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-      <CrewList />
+      <nav>
+        <ul>
+          <li><Link to="/">Home</Link></li>
+          <li><Link to="/profile">Profile</Link></li>
+          <li><Link to="/recruit">Recruit</Link></li>
+          <li><Link to="/parcels/1">Parcels</Link></li>
+          <li><Link to="/train">Train</Link></li>
+          <li><Link to="/deploy">Deploy</Link></li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/" element={<CrewList />} />
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/recruit" element={<RecruitPage />} />
+        <Route path="/parcels/:id" element={<ParcelsPage />} />
+        <Route path="/train" element={<TrainPage />} />
+        <Route path="/deploy" element={<DeployPage />} />
+      </Routes>
     </>
   )
 }

--- a/game-site/src/main.tsx
+++ b/game-site/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/game-site/src/pages/DeployPage.tsx
+++ b/game-site/src/pages/DeployPage.tsx
@@ -1,0 +1,5 @@
+function DeployPage() {
+  return <p>Coming Soon</p>
+}
+
+export default DeployPage

--- a/game-site/src/pages/ParcelsPage.tsx
+++ b/game-site/src/pages/ParcelsPage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+interface ParcelSlot {
+  opened: boolean
+}
+
+function ParcelsPage() {
+  const { id } = useParams()
+  const [slots, setSlots] = useState<ParcelSlot[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    async function loadParcels() {
+      try {
+        const res = await fetch(`/api/crews/${id}/parcels`)
+        if (!res.ok) {
+          throw new Error('Failed to load parcels')
+        }
+        const data = await res.json()
+        setSlots(data)
+      } catch {
+        setError('Unable to load parcels. Please try again later.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (id) {
+      loadParcels()
+    }
+  }, [id])
+
+  async function handleOpen(index: number) {
+    if (!id) return
+    try {
+      const res = await fetch(`/api/crews/${id}/parcels/open`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slotIndex: index, stamps: 1 }),
+      })
+      if (!res.ok) {
+        throw new Error('Failed to open parcel')
+      }
+      const data = await res.json()
+      setSlots(data.parcels)
+    } catch {
+      setError('Unable to open parcel. Please try again later.')
+    }
+  }
+
+  if (error) {
+    return <p role="alert">{error}</p>
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <section aria-labelledby="parcels-heading">
+      <h1 id="parcels-heading">Crew {id} Parcels</h1>
+      <ul>
+        {slots.map((slot, index) => (
+          <li key={index}>
+            {slot.opened ? (
+              'Opened'
+            ) : (
+              <button onClick={() => handleOpen(index)}>Open</button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default ParcelsPage

--- a/game-site/src/pages/ProfilePage.tsx
+++ b/game-site/src/pages/ProfilePage.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+interface Profile {
+  rank: string
+  stamps: number
+  bonds: number
+}
+
+function ProfilePage() {
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    async function loadProfile() {
+      try {
+        const res = await fetch('/api/user/profile')
+        if (!res.ok) {
+          throw new Error('Failed to load profile')
+        }
+        const data = await res.json()
+        setProfile(data)
+      } catch {
+        setError('Unable to load profile. Please try again later.')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadProfile()
+  }, [])
+
+  if (error) {
+    return <p role="alert">{error}</p>
+  }
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  if (!profile) {
+    return null
+  }
+
+  return (
+    <section aria-labelledby="profile-heading">
+      <h1 id="profile-heading">Profile</h1>
+      <p>Rank: {profile.rank}</p>
+      <p>Stamps: {profile.stamps}</p>
+      <p>Bonds: {profile.bonds}</p>
+    </section>
+  )
+}
+
+export default ProfilePage

--- a/game-site/src/pages/RecruitPage.tsx
+++ b/game-site/src/pages/RecruitPage.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+function RecruitPage() {
+  const [count, setCount] = useState(1)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setMessage('')
+    setError('')
+    try {
+      const res = await fetch('/api/crews/recruit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ count }),
+      })
+      if (!res.ok) {
+        throw new Error('Failed to recruit crew')
+      }
+      setMessage('Recruitment successful!')
+    } catch {
+      setError('Unable to recruit crew. Please try again later.')
+    }
+  }
+
+  return (
+    <section aria-labelledby="recruit-heading">
+      <h1 id="recruit-heading">Recruit Crew</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Crew Count:
+          <input
+            type="number"
+            min="1"
+            value={count}
+            onChange={(e) => setCount(Number(e.target.value))}
+          />
+        </label>
+        <button type="submit">Recruit</button>
+      </form>
+      {message && <p>{message}</p>}
+      {error && <p role="alert">{error}</p>}
+    </section>
+  )
+}
+
+export default RecruitPage

--- a/game-site/src/pages/TrainPage.tsx
+++ b/game-site/src/pages/TrainPage.tsx
@@ -1,0 +1,5 @@
+function TrainPage() {
+  return <p>Coming Soon</p>
+}
+
+export default TrainPage


### PR DESCRIPTION
## Summary
- add React Router dependency and init BrowserRouter
- create crew manager pages: Profile, Recruit, Parcels, Train and Deploy
- wire up navigation and routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e25fda880832ab8f1666eb72e8e2a