### PR TITLE
feat(ui): add register & login pages

### DIFF
--- a/game-site/src/App.tsx
+++ b/game-site/src/App.tsx
@@ -5,6 +5,8 @@ import RecruitPage from './pages/RecruitPage'
 import ParcelsPage from './pages/ParcelsPage'
 import TrainPage from './pages/TrainPage'
 import DeployPage from './pages/DeployPage'
+import RegisterPage from './pages/RegisterPage'
+import LoginPage from './pages/LoginPage'
 
 function App() {
   return (
@@ -13,6 +15,8 @@ function App() {
         <ul>
           <li><Link to="/">Home</Link></li>
           <li><Link to="/profile">Profile</Link></li>
+          <li><Link to="/login">Login</Link></li>
+          <li><Link to="/register">Register</Link></li>
           <li><Link to="/recruit">Recruit</Link></li>
           <li><Link to="/parcels/1">Parcels</Link></li>
           <li><Link to="/train">Train</Link></li>
@@ -22,6 +26,8 @@ function App() {
       <Routes>
         <Route path="/" element={<CrewList />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
         <Route path="/recruit" element={<RecruitPage />} />
         <Route path="/parcels/:id" element={<ParcelsPage />} />
         <Route path="/train" element={<TrainPage />} />

--- a/game-site/src/pages/LoginPage.tsx
+++ b/game-site/src/pages/LoginPage.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function LoginPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (!res.ok) {
+        throw new Error('Failed to login')
+      }
+      const data = await res.json()
+      if (data.token) {
+        localStorage.setItem('token', data.token)
+        navigate('/profile')
+      }
+    } catch {
+      setError('Unable to login. Please try again later.')
+    }
+  }
+
+  return (
+    <section aria-labelledby="login-heading">
+      <h1 id="login-heading">Login</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email:
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label>
+          Password:
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        <button type="submit">Login</button>
+      </form>
+      {error && <p role="alert">{error}</p>}
+    </section>
+  )
+}
+
+export default LoginPage

--- a/game-site/src/pages/RegisterPage.tsx
+++ b/game-site/src/pages/RegisterPage.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function RegisterPage() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      })
+      if (!res.ok) {
+        throw new Error('Failed to register')
+      }
+      const data = await res.json()
+      if (data.token) {
+        localStorage.setItem('token', data.token)
+        navigate('/profile')
+      }
+    } catch {
+      setError('Unable to register. Please try again later.')
+    }
+  }
+
+  return (
+    <section aria-labelledby="register-heading">
+      <h1 id="register-heading">Register</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email:
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </label>
+        <label>
+          Password:
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </label>
+        <button type="submit">Register</button>
+      </form>
+      {error && <p role="alert">{error}</p>}
+    </section>
+  )
+}
+
+export default RegisterPage


### PR DESCRIPTION
## Summary
- create RegisterPage for new user sign up
- create LoginPage for existing user sign in
- wire up new routes and nav links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f59b04be4832abf1925875727c477