### PR TITLE
feat(ui): implement AuthContext and protected routes

### DIFF
--- a/game-site/src/App.tsx
+++ b/game-site/src/App.tsx
@@ -7,6 +7,7 @@ import TrainPage from './pages/TrainPage'
 import DeployPage from './pages/DeployPage'
 import RegisterPage from './pages/RegisterPage'
 import LoginPage from './pages/LoginPage'
+import RequireAuth from './RequireAuth'
 
 function App() {
   return (
@@ -25,13 +26,48 @@ function App() {
       </nav>
       <Routes>
         <Route path="/" element={<CrewList />} />
-        <Route path="/profile" element={<ProfilePage />} />
+        <Route
+          path="/profile"
+          element={(
+            <RequireAuth>
+              <ProfilePage />
+            </RequireAuth>
+          )}
+        />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/recruit" element={<RecruitPage />} />
-        <Route path="/parcels/:id" element={<ParcelsPage />} />
-        <Route path="/train" element={<TrainPage />} />
-        <Route path="/deploy" element={<DeployPage />} />
+        <Route
+          path="/recruit"
+          element={(
+            <RequireAuth>
+              <RecruitPage />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/parcels/:id"
+          element={(
+            <RequireAuth>
+              <ParcelsPage />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/train"
+          element={(
+            <RequireAuth>
+              <TrainPage />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/deploy"
+          element={(
+            <RequireAuth>
+              <DeployPage />
+            </RequireAuth>
+          )}
+        />
       </Routes>
     </>
   )

--- a/game-site/src/AuthContext.tsx
+++ b/game-site/src/AuthContext.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from 'react'
+
+interface AuthContextValue {
+  token: string | null
+  user: unknown
+  login: (token: string, user?: unknown) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  user: null,
+  login: () => {},
+  logout: () => {},
+})
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null)
+  const [user, setUser] = useState<unknown>(null)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('token')
+    if (stored) {
+      setToken(stored)
+    }
+  }, [])
+
+  const login = (newToken: string, newUser?: unknown) => {
+    setToken(newToken)
+    setUser(newUser ?? null)
+    localStorage.setItem('token', newToken)
+  }
+
+  const logout = () => {
+    setToken(null)
+    setUser(null)
+    localStorage.removeItem('token')
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  return useContext(AuthContext)
+}
+
+export function useAuthFetch() {
+  const { token } = useAuth()
+  return (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const headers = new Headers(init.headers)
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`)
+    }
+    return fetch(input, { ...init, headers })
+  }
+}

--- a/game-site/src/RequireAuth.tsx
+++ b/game-site/src/RequireAuth.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+function RequireAuth({ children }: { children: ReactNode }) {
+  const { token } = useAuth()
+  const location = useLocation()
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  return children
+}
+
+export default RequireAuth

--- a/game-site/src/components/CrewList.tsx
+++ b/game-site/src/components/CrewList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useAuthFetch } from '../AuthContext'
 
 interface CrewMember {
   name: string
@@ -15,11 +16,12 @@ function CrewList() {
   const [crews, setCrews] = useState<Crew[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const authFetch = useAuthFetch()
 
   useEffect(() => {
     async function loadCrews() {
       try {
-        const res = await fetch('/api/crews')
+        const res = await authFetch('/api/crews')
         if (!res.ok) {
           throw new Error('Failed to load crews')
         }
@@ -33,7 +35,7 @@ function CrewList() {
     }
 
     loadCrews()
-  }, [])
+  }, [authFetch])
 
   if (error) {
     return <p role="alert">{error}</p>

--- a/game-site/src/main.tsx
+++ b/game-site/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from './AuthContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/game-site/src/pages/LoginPage.tsx
+++ b/game-site/src/pages/LoginPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../AuthContext'
 
 function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { login } = useAuth()
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -21,7 +23,7 @@ function LoginPage() {
       }
       const data = await res.json()
       if (data.token) {
-        localStorage.setItem('token', data.token)
+        login(data.token)
         navigate('/profile')
       }
     } catch {

--- a/game-site/src/pages/ParcelsPage.tsx
+++ b/game-site/src/pages/ParcelsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { useAuthFetch } from '../AuthContext'
 
 interface ParcelSlot {
   opened: boolean
@@ -10,11 +11,12 @@ function ParcelsPage() {
   const [slots, setSlots] = useState<ParcelSlot[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const authFetch = useAuthFetch()
 
   useEffect(() => {
     async function loadParcels() {
       try {
-        const res = await fetch(`/api/crews/${id}/parcels`)
+        const res = await authFetch(`/api/crews/${id}/parcels`)
         if (!res.ok) {
           throw new Error('Failed to load parcels')
         }
@@ -30,12 +32,12 @@ function ParcelsPage() {
     if (id) {
       loadParcels()
     }
-  }, [id])
+  }, [id, authFetch])
 
   async function handleOpen(index: number) {
     if (!id) return
     try {
-      const res = await fetch(`/api/crews/${id}/parcels/open`, {
+      const res = await authFetch(`/api/crews/${id}/parcels/open`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ slotIndex: index, stamps: 1 }),

--- a/game-site/src/pages/ProfilePage.tsx
+++ b/game-site/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useAuthFetch } from '../AuthContext'
 
 interface Profile {
   rank: string
@@ -10,11 +11,12 @@ function ProfilePage() {
   const [profile, setProfile] = useState<Profile | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const authFetch = useAuthFetch()
 
   useEffect(() => {
     async function loadProfile() {
       try {
-        const res = await fetch('/api/user/profile')
+        const res = await authFetch('/api/user/profile')
         if (!res.ok) {
           throw new Error('Failed to load profile')
         }
@@ -28,7 +30,7 @@ function ProfilePage() {
     }
 
     loadProfile()
-  }, [])
+  }, [authFetch])
 
   if (error) {
     return <p role="alert">{error}</p>

--- a/game-site/src/pages/RecruitPage.tsx
+++ b/game-site/src/pages/RecruitPage.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react'
+import { useAuthFetch } from '../AuthContext'
 
 function RecruitPage() {
   const [count, setCount] = useState(1)
   const [message, setMessage] = useState('')
   const [error, setError] = useState('')
+  const authFetch = useAuthFetch()
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setMessage('')
     setError('')
     try {
-      const res = await fetch('/api/crews/recruit', {
+      const res = await authFetch('/api/crews/recruit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ count }),

--- a/game-site/src/pages/RegisterPage.tsx
+++ b/game-site/src/pages/RegisterPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../AuthContext'
 
 function RegisterPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { login } = useAuth()
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -21,7 +23,7 @@ function RegisterPage() {
       }
       const data = await res.json()
       if (data.token) {
-        localStorage.setItem('token', data.token)
+        login(data.token)
         navigate('/profile')
       }
     } catch {


### PR DESCRIPTION
## Summary
- create `AuthContext` with login/logout helpers and authorized fetch hook
- guard pages with `RequireAuth` and wrap routes
- add `AuthProvider` around application
- update pages to use new context and header logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f5c92c86c832ab850455b5dc1be1b