### PR TITLE
docs: document auth and user-scoped endpoints

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,1 +1,38 @@
-﻿# Tutorials
+# Tutorials
+## Authentication & Multi-user
+
+### Register & Login
+
+Use the authentication endpoints to create an account and obtain a JWT.
+
+`POST /api/auth/register`
+
+Request:
+```json
+{ "email": "user@example.com", "password": "secret" }
+```
+Response:
+```json
+{ "token": "<jwt>" }
+```
+
+`POST /api/auth/login`
+
+Request:
+```json
+{ "email": "user@example.com", "password": "secret" }
+```
+Response:
+```json
+{ "token": "<jwt>" }
+```
+
+Once logged in, include the JWT in the `Authorization` header for
+protected requests:
+
+```
+Authorization: Bearer <jwt>
+```
+
+All crew, parcel and card endpoints now require this header.
+


### PR DESCRIPTION
## Summary
- describe how to register and log in
- explain sending the JWT via `Authorization` header
- mention that crew, parcel and card APIs require auth

## Testing
- `mkdocs build -q`

------
https://chatgpt.com/codex/tasks/task_e_684f619e2e58832a856653943ef547e9